### PR TITLE
:bug: 在使用 satori 适配器时不能响应例如 武汉天气 的指令

### DIFF
--- a/liteyuki/plugins/liteyuki_weather/qweather.py
+++ b/liteyuki/plugins/liteyuki_weather/qweather.py
@@ -14,30 +14,30 @@ from liteyuki.utils.message.html_tool import template2image
 from liteyuki.utils import event as event_utils
 
 require("nonebot_plugin_alconna")
-from nonebot_plugin_alconna import on_alconna, Alconna, Args, MultiVar, Arparma
+from nonebot_plugin_alconna import on_alconna, Alconna, Args, MultiVar, Arparma, UniMessage
 
-
-@on_alconna(
+wrx_alc = on_alconna(
     aliases={"天气"},
     command=Alconna(
         "weather",
         Args["keywords", MultiVar(str), []],
     ),
-).handle()
+)
+
+
+@wrx_alc.handle()
 async def _(result: Arparma, event: T_MessageEvent, matcher: Matcher):
     """await alconna.send("weather", city)"""
     kws = result.main_args.get("keywords")
     image = await get_weather_now_card(matcher, event, kws)
-    if isinstance(event, satori.event.Event):
-        await matcher.finish(satori.MessageSegment.image(raw=image, mime="image/png"))
-    else:
-        await matcher.finish(MessageSegment.image(image))
+    await wrx_alc.finish(UniMessage.image(raw=image))
 
 
 @on_endswith(("天气", "weather")).handle()
 async def _(event: T_MessageEvent, matcher: Matcher):
     """await alconna.send("weather", city)"""
-    kws = event.message.extract_plain_text()
+    # kws = event.message.extract_plain_text()
+    kws = event.get_plaintext()
     image = await get_weather_now_card(matcher, event, [kws.replace("天气", "").replace("weather", "")], False)
     await matcher.finish(MessageSegment.image(image))
 

--- a/liteyuki/plugins/liteyuki_weather/qweather.py
+++ b/liteyuki/plugins/liteyuki_weather/qweather.py
@@ -16,7 +16,7 @@ from liteyuki.utils import event as event_utils
 require("nonebot_plugin_alconna")
 from nonebot_plugin_alconna import on_alconna, Alconna, Args, MultiVar, Arparma, UniMessage
 
-wrx_alc = on_alconna(
+wx_alc = on_alconna(
     aliases={"天气"},
     command=Alconna(
         "weather",
@@ -25,12 +25,12 @@ wrx_alc = on_alconna(
 )
 
 
-@wrx_alc.handle()
+@wx_alc.handle()
 async def _(result: Arparma, event: T_MessageEvent, matcher: Matcher):
     """await alconna.send("weather", city)"""
     kws = result.main_args.get("keywords")
     image = await get_weather_now_card(matcher, event, kws)
-    await wrx_alc.finish(UniMessage.image(raw=image))
+    await wx_alc.finish(UniMessage.image(raw=image))
 
 
 @on_endswith(("天气", "weather")).handle()

--- a/liteyuki/plugins/liteyuki_weather/qweather.py
+++ b/liteyuki/plugins/liteyuki_weather/qweather.py
@@ -39,7 +39,10 @@ async def _(event: T_MessageEvent, matcher: Matcher):
     # kws = event.message.extract_plain_text()
     kws = event.get_plaintext()
     image = await get_weather_now_card(matcher, event, [kws.replace("天气", "").replace("weather", "")], False)
-    await matcher.finish(MessageSegment.image(image))
+    if isinstance(event, satori.event.Event):
+        await matcher.finish(satori.MessageSegment.image(raw=image, mime="image/png"))
+    else:
+        await matcher.finish(MessageSegment.image(image))
 
 
 async def get_weather_now_card(matcher: Matcher, event: T_MessageEvent, keyword: list[str], tip: bool = True):


### PR DESCRIPTION
### 修复内容
- :bug: 在使用 satori 适配器时不能响应例如 武汉天气 的指令

### 更改内容
- 使用 alconna 响应例如 天气武汉的回复

### 测试
- 更改已在 Satori 和 Onebot 下测试